### PR TITLE
Updated Postgres connection string in docker-compose.yml file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     ports:
       - "8000:8000"
     environment:
-      DB_CONNECTION: "postgres://postgres:postgres@db/postgres"
+      DB_CONNECTION: "postgresql://postgres:postgres@db/postgres"
     env_file:
       - .env
     depends_on:


### PR DESCRIPTION
I updated the Postgres connection string in the docker-compose.yml file to match the format that sqlalchemy is now expecting (`"postgresql://"` instead of `"postgres://"`). It looks like the connection string is correct everywhere else.

I was getting the following error before updating the connection string:
`sqlalchemy.exc.NoSuchModuleError: Can't load plugin: sqlalchemy.dialects:postgres`